### PR TITLE
Add notifications dropdown data and open-by-id support

### DIFF
--- a/site_bot/main.py
+++ b/site_bot/main.py
@@ -579,10 +579,11 @@ async def api_notifications():
     )
     for q in q_rows:
         short = q["text"][:30] + ("…" if len(q["text"]) > 30 else "")
+        text = f"Вопрос: {short}"
         notifications.append({
             "type": "question",
             "id": q["id"],
-            "text": short,
+            "text": text,
         })
 
     return {"notifications": notifications}

--- a/site_bot/main.py
+++ b/site_bot/main.py
@@ -551,6 +551,43 @@ async def api_draw_stage_test_mailing(stage_id: int):
     return {"success": True}
 
 
+@app.get("/api/notifications")
+async def api_notifications():
+    """Return receipts with status 'Не распознан' and unanswered questions."""
+    notifications = []
+
+    if has_receipt_status():
+        rec_rows = await database.fetch_all(
+            sqlalchemy.select(
+                receipts_table.c.id,
+                receipts_table.c.number,
+            ).where(receipts_table.c.status == "Не распознан")
+        )
+        for r in rec_rows:
+            text = f"Чек {r['number'] or r['id']} не распознан"
+            notifications.append({
+                "type": "receipt",
+                "id": r["id"],
+                "text": text,
+            })
+
+    q_rows = await database.fetch_all(
+        sqlalchemy.select(
+            questions_table.c.id,
+            questions_table.c.text,
+        ).where(questions_table.c.status == "Новый")
+    )
+    for q in q_rows:
+        short = q["text"][:30] + ("…" if len(q["text"]) > 30 else "")
+        notifications.append({
+            "type": "question",
+            "id": q["id"],
+            "text": short,
+        })
+
+    return {"notifications": notifications}
+
+
 @app.post("/api/draw-stages/{stage_id}/mailing")
 async def api_draw_stage_mailing(stage_id: int):
     stage = await database.fetch_one(

--- a/site_bot/templates/base.html
+++ b/site_bot/templates/base.html
@@ -220,21 +220,43 @@
             if (list.length === 0) return;
             const empty = document.getElementById('notifications-empty');
             if (empty) empty.remove();
-            list.forEach(n => {
+
+            const receipts = list.filter(n => n.type === 'receipt');
+            const questions = list.filter(n => n.type === 'question');
+
+            const createItem = (href, iconCls, text) => {
               const li = document.createElement('li');
-              const a  = document.createElement('a');
-              a.className = 'dropdown-item';
-              if (n.type === 'receipt') {
-                a.href = `/receipts?open=${n.id}`;
-              } else if (n.type === 'question') {
-                a.href = `/questions?open=${n.id}`;
-              } else {
-                a.href = '#';
-              }
-              a.textContent = n.text;
+              const a = document.createElement('a');
+              a.className = 'dropdown-item d-flex align-items-center gap-2';
+              a.href = href;
+              a.innerHTML = `<i class="bi ${iconCls}"></i> <span>${text}</span>`;
               li.appendChild(a);
-              menu.appendChild(li);
-            });
+              return li;
+            };
+
+            if (receipts.length) {
+              const header = document.createElement('li');
+              header.innerHTML = '<h6 class="dropdown-header">Нераспознанные чеки</h6>';
+              menu.appendChild(header);
+              receipts.forEach(r => menu.appendChild(
+                createItem(`/receipts?open=${r.id}`, 'bi-receipt text-danger', r.text)
+              ));
+            }
+
+            if (receipts.length && questions.length) {
+              const div = document.createElement('li');
+              div.innerHTML = '<hr class="dropdown-divider">';
+              menu.appendChild(div);
+            }
+
+            if (questions.length) {
+              const header = document.createElement('li');
+              header.innerHTML = '<h6 class="dropdown-header">Вопросы без ответа</h6>';
+              menu.appendChild(header);
+              questions.forEach(q => menu.appendChild(
+                createItem(`/questions?open=${q.id}`, 'bi-question-circle text-warning', q.text)
+              ));
+            }
           });
       });
     </script>

--- a/site_bot/templates/base.html
+++ b/site_bot/templates/base.html
@@ -123,9 +123,10 @@
               <ul
                 class="dropdown-menu dropdown-menu-end"
                 aria-labelledby="notificationsDropdown"
+                id="notificationsMenu"
               >
                 <li><h6 class="dropdown-header">Уведомления</h6></li>
-                <li>
+                <li id="notifications-empty">
                   <span class="dropdown-item-text text-muted">Нет новых уведомлений</span>
                 </li>
               </ul>
@@ -202,10 +203,40 @@
     <!-- === Конец основного контейнера === -->
 
     <!-- Bootstrap JS Bundle -->
-    <script
+  <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js?v={{ version }}"
       integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
       crossorigin="anonymous"
     ></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const menu  = document.getElementById('notificationsMenu');
+        const badge = document.querySelector('#notificationsDropdown .badge');
+        fetch('/api/notifications')
+          .then(r => r.json())
+          .then(data => {
+            const list = data.notifications || [];
+            badge.textContent = list.length;
+            if (list.length === 0) return;
+            const empty = document.getElementById('notifications-empty');
+            if (empty) empty.remove();
+            list.forEach(n => {
+              const li = document.createElement('li');
+              const a  = document.createElement('a');
+              a.className = 'dropdown-item';
+              if (n.type === 'receipt') {
+                a.href = `/receipts?open=${n.id}`;
+              } else if (n.type === 'question') {
+                a.href = `/questions?open=${n.id}`;
+              } else {
+                a.href = '#';
+              }
+              a.textContent = n.text;
+              li.appendChild(a);
+              menu.appendChild(li);
+            });
+          });
+      });
+    </script>
   </body>
 </html>

--- a/site_bot/templates/questions.html
+++ b/site_bot/templates/questions.html
@@ -314,6 +314,12 @@
 
       // старт
       renderQuestions();
+      const params = new URLSearchParams(location.search);
+      const openId = params.get('open');
+      if (openId) {
+        const q = questionsData.find(x => String(x.id) === openId);
+        if (q) openConversation(q);
+      }
     });
   </script>
 {% endblock %}

--- a/site_bot/templates/receipts.html
+++ b/site_bot/templates/receipts.html
@@ -305,6 +305,33 @@
       };
       applyFilter();
       render();
+      const params = new URLSearchParams(location.search);
+      const openId = params.get('open');
+      if (openId) {
+        const rec = data.find(r => String(r.id) === openId);
+        if (rec) {
+          fetch(`/api/receipts/${rec.id}`)
+            .then(res => res.json())
+            .then(recData => {
+              document.getElementById('receipt-img').src = recData.file_path;
+              document.getElementById('receipt-img-full').src = recData.file_path;
+              document.getElementById('view-number').textContent = recData.number;
+              document.getElementById('view-date').textContent = new Date(recData.created_at).toLocaleDateString('ru-RU');
+              const userLinkEl = document.getElementById('view-user');
+              userLinkEl.textContent = recData.user_name ?? recData.user_tg_id;
+              userLinkEl.href = `/participants?open=${recData.user_tg_id}`;
+              document.getElementById('receipt-status').value = recData.status ?? '';
+              const drawSel = document.getElementById('receipt-draw');
+              drawSel.innerHTML = '<option value="">---</option>' + draws.map(d => `<option value="${d.id}">${d.title}</option>`).join('');
+              drawSel.value = recData.draw_id ?? '';
+              document.getElementById('go-dialog').onclick = () => {
+                window.location.href = `/participants?open=${recData.user_tg_id}`;
+              };
+              currentReceiptId = recData.id;
+              new bootstrap.Modal(document.getElementById('modal-receipt-view')).show();
+            });
+        }
+      }
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- provide new `/api/notifications` endpoint to fetch receipts with status `Не распознан` and unanswered questions
- fill notifications dropdown via JS and update badge count
- open receipts or questions when `?open=` parameter is present

## Testing
- `python -m py_compile site_bot/main.py`
- `pytest -q` *(fails: ImportError while importing bot_test.py)*

------
https://chatgpt.com/codex/tasks/task_e_6875420868608327a05d23c7c856ffa0