### PR TITLE
Update receipt messaging and catalog upload handling

### DIFF
--- a/heandlers/media_heandler.py
+++ b/heandlers/media_heandler.py
@@ -6,7 +6,7 @@ import math
 import os
 import re
 import threading
-from aiogram.types import Message
+from aiogram.types import Message, FSInputFile
 import time
 import random
 import uuid
@@ -993,6 +993,17 @@ async def set_photo(message: Message) -> None:
         if await sql_mgt.is_user_blocked(message.chat.id):
             await message.reply('Вы заблокированы и не можете участвовать в розыгрыше')
             return
+        draw_id = await sql_mgt.get_active_draw_id()
+        if draw_id is None:
+            await sql_mgt.set_param(message.chat.id, 'GET_CHECK', str(False))
+            await message.reply(
+                "📫-Сейчас акция не проводится\n"
+                "Следите за рассылками в чат-боте – мы обязательно сообщим о старте новых промоакций!"
+            )
+            return
+        existing_receipts = await sql_mgt.get_user_receipts(
+            message.chat.id, limit=None, draw_id=draw_id
+        )
         photo = message.photo[-1]
         try:
             photo_file = await global_objects.bot.download(photo.file_id)
@@ -1002,7 +1013,6 @@ async def set_photo(message: Message) -> None:
                 f.write(photo_file.getvalue())
 
             web_path = f"/static/uploads/{fname}"
-            draw_id = await sql_mgt.get_active_draw_id()
             receipt_id = await sql_mgt.add_receipt(
                 web_path,
                 message.chat.id,
@@ -1011,9 +1021,28 @@ async def set_photo(message: Message) -> None:
                 draw_id=draw_id,
             )
             await sql_mgt.enqueue_receipt_ocr(receipt_id)
-            await message.reply(
-                'Чек загружен и находится в статусе Проверка. Как проверка будет пройдена, мы вам сообщим.'
-            )
+            receipts_total = len(existing_receipts) + 1
+            if receipts_total == 1:
+                first_receipt_text = (
+                    "Поздравляем! Теперь вы участвуете в розыгрыше призов 🎁\n"
+                    "Держите подарок – электронный каталог коктейлей FINSKY ICE🧊\n"
+                    "Чем больше чеков, тем выше шансы на победу! Хотите загрузить еще чеки?🧾"
+                )
+                catalog_path = await sql_mgt.get_param(0, "CATALOG_FILE")
+                if catalog_path:
+                    catalog_local = Path(__file__).resolve().parent.parent / "site_bot" / catalog_path.lstrip("/")
+                    if catalog_local.exists():
+                        await message.reply_document(
+                            FSInputFile(catalog_local, filename=catalog_local.name),
+                            caption=first_receipt_text,
+                        )
+                        return
+                await message.reply(first_receipt_text)
+            else:
+                await message.reply(
+                    "Чек загружен и находится в статусе Проверка.\n"
+                    "Хотите загрузить еще, чтобы повысить шансы на выигрыш? 🎁 "
+                )
             return
         except Exception:
             await message.reply('Ошибка при обработке чека. Попробуйте ещё раз.')

--- a/heandlers/menu.py
+++ b/heandlers/menu.py
@@ -172,22 +172,15 @@ async def get_message(message: Message, path=SPLITTER_STR, replace=False):
         receipts = []
         await sql_mgt.set_param(message.chat.id, 'CHECK_BUTTON_MAP', '')
         if active_draw_id is None:
-            no_promo_text = (
+            text_message = (
                 "📫-Сейчас акция не проводится\n"
                 "Следите за рассылками в чат-боте – мы обязательно сообщим о старте новых промоакций!"
             )
-            text_message = f"{text_message}\n\n{no_promo_text}" if text_message else no_promo_text
         else:
-            promo_text = (
-                "Не упустите свой шанс: FINSKY ICE проводит акцию для своих покупателей!\n"
-                "Участвовать очень просто – приобретайте продукцию FINSKY ICE, отправляйте фото или QR-код чека в чат-бот и ждите результатов✨"
-            )
-            text_message = f"{text_message}\n\n{promo_text}" if text_message else promo_text
             receipts = await sql_mgt.get_user_receipts(
                 message.chat.id, limit=None, draw_id=active_draw_id
             )
             if receipts:
-                me = await global_objects.bot.get_me()
                 text_message += "\n\nВаши чеки:\n"
                 for r in receipts:
                     ts = r.get("create_dt")
@@ -197,10 +190,9 @@ async def get_message(message: Message, path=SPLITTER_STR, replace=False):
                         name = ts.replace("T", " ")[:16]
                     else:
                         name = f"Чек #{r['id']}"
-                    link = f"https://t.me/{me.username}?start=receipt_{r['id']}"
                     status = (r.get('status') or '').lower()
                     mark = STATUS_ICON_MAP.get(status, DEFAULT_STATUS_ICON)
-                    text_message += f'<a href="{link}">{name}</a> {mark}\n'
+                    text_message += f"{name} {mark}\n"
     else:
         await sql_mgt.set_param(message.chat.id, 'CHECK_BUTTON_MAP', '')
 

--- a/heandlers/menu.py
+++ b/heandlers/menu.py
@@ -181,6 +181,7 @@ async def get_message(message: Message, path=SPLITTER_STR, replace=False):
                 message.chat.id, limit=None, draw_id=active_draw_id
             )
             if receipts:
+                me = await global_objects.bot.get_me()
                 text_message += "\n\nВаши чеки:\n"
                 for r in receipts:
                     ts = r.get("create_dt")
@@ -190,9 +191,10 @@ async def get_message(message: Message, path=SPLITTER_STR, replace=False):
                         name = ts.replace("T", " ")[:16]
                     else:
                         name = f"Чек #{r['id']}"
+                    link = f"https://t.me/{me.username}?start=receipt_{r['id']}"
                     status = (r.get('status') or '').lower()
                     mark = STATUS_ICON_MAP.get(status, DEFAULT_STATUS_ICON)
-                    text_message += f"{name} {mark}\n"
+                    text_message += f'<a href="{link}">{name}</a> {mark}\n'
     else:
         await sql_mgt.set_param(message.chat.id, 'CHECK_BUTTON_MAP', '')
 
@@ -214,13 +216,19 @@ async def get_message(message: Message, path=SPLITTER_STR, replace=False):
             print(f"Не удалось удалить служебное сообщение меню: {error}")
 
         if replace:
-            await message.edit_text(text_message, reply_markup=inline_kb, parse_mode=ParseMode.HTML)
+            await message.edit_text(
+                text_message,
+                reply_markup=inline_kb,
+                parse_mode=ParseMode.HTML,
+                disable_web_page_preview=True,
+            )
         else:
             last_message = await message.answer(
                 text_message,
                 reply_markup=inline_kb,
                 parse_mode=ParseMode.HTML,
-                disable_notification=True
+                disable_notification=True,
+                disable_web_page_preview=True,
             )
             last_message_id_new = last_message.message_id
             await sql_mgt.set_param(message.chat.id, 'LAST_MESSAGE_ID', str(last_message_id_new))
@@ -242,13 +250,19 @@ async def get_message(message: Message, path=SPLITTER_STR, replace=False):
                         replace_last_messages = False
     else:
         if replace:
-            await message.edit_text(text_message, reply_markup=reply_kb, parse_mode=ParseMode.HTML)
+            await message.edit_text(
+                text_message,
+                reply_markup=reply_kb,
+                parse_mode=ParseMode.HTML,
+                disable_web_page_preview=True,
+            )
         else:
             last_message = await message.answer(
                 text_message,
                 reply_markup=reply_kb,
                 parse_mode=ParseMode.HTML,
-                disable_notification=True
+                disable_notification=True,
+                disable_web_page_preview=True,
             )
             last_message_id_new = last_message.message_id
             await sql_mgt.set_param(message.chat.id, 'LAST_MESSAGE_ID', str(last_message_id_new))

--- a/heandlers/menu.py
+++ b/heandlers/menu.py
@@ -172,11 +172,17 @@ async def get_message(message: Message, path=SPLITTER_STR, replace=False):
         receipts = []
         await sql_mgt.set_param(message.chat.id, 'CHECK_BUTTON_MAP', '')
         if active_draw_id is None:
-            text_message = (
-                "На данный момент активных розыгрышей нету.\n"
-                "Мы сообщим вам, когда можно будет принять участие в новом!"
+            no_promo_text = (
+                "📫-Сейчас акция не проводится\n"
+                "Следите за рассылками в чат-боте – мы обязательно сообщим о старте новых промоакций!"
             )
+            text_message = f"{text_message}\n\n{no_promo_text}" if text_message else no_promo_text
         else:
+            promo_text = (
+                "Не упустите свой шанс: FINSKY ICE проводит акцию для своих покупателей!\n"
+                "Участвовать очень просто – приобретайте продукцию FINSKY ICE, отправляйте фото или QR-код чека в чат-бот и ждите результатов✨"
+            )
+            text_message = f"{text_message}\n\n{promo_text}" if text_message else promo_text
             receipts = await sql_mgt.get_user_receipts(
                 message.chat.id, limit=None, draw_id=active_draw_id
             )

--- a/heandlers/text_heandler.py
+++ b/heandlers/text_heandler.py
@@ -50,9 +50,9 @@ async def set_text(message: Message) -> None:
         await admin.except_message(message, except_message_name)
         return
 
-    # не перехватываем сообщения в режиме загрузки чеков
     is_get_check = await sql_mgt.get_param(message.chat.id, 'GET_CHECK')
     if is_get_check == str(True):
+        await _send_default_hint(message)
         return
 
     # режим приёма вопросов

--- a/site_bot/js/settings.js
+++ b/site_bot/js/settings.js
@@ -1754,6 +1754,15 @@ async function openSettingsSite() {
                         <input type="file" id="rules-file" name="rules_file">
                     </div>
                 </div>
+                <div style="margin-bottom: 20px;">
+                    <div class="nameInput">
+                        <img class="icon_arrow" src="icon/Line 15.png" alt="">
+                        <label for="catalog-file">Электронный каталог коктейлей</label>
+                    </div>
+                    <div class="textareaInput">
+                        <input type="file" id="catalog-file" name="catalog_file">
+                    </div>
+                </div>
                 <button id="save-settings-site" class="btn btnGreen">Сохранить</button>
             </form>
         `;

--- a/site_bot/settings.html
+++ b/site_bot/settings.html
@@ -2511,6 +2511,15 @@
                             <input type="file" id="rules-file" name="rules_file">
                         </div>
                     </div>
+                    <div style="margin-bottom: 20px;">
+                        <div class="nameInput">
+                            <img class="icon_arrow" src="icon/Line 15.png" alt="">
+                            <label for="catalog-file">Электронный каталог коктейлей</label>
+                        </div>
+                        <div class="textareaInput">
+                            <input type="file" id="catalog-file" name="catalog_file">
+                        </div>
+                    </div>
 
                     <div class="fixed_done_manipulator" style="padding-bottom: 4%;">
                     <img style="margin-left: 6%;" width="30px" src="icon/Ellipse 34.png" class="back___btn light_theme" alt="" onclick="setMenuDiv('settings')">

--- a/site_bot/templates/settings.html
+++ b/site_bot/templates/settings.html
@@ -31,6 +31,13 @@
         {% endif %}
         <input type="file" class="form-control" id="rules-file" name="rules_file" />
       </div>
+      <div class="mb-3">
+        <label for="catalog-file" class="form-label">Электронный каталог коктейлей</label>
+        {% if catalog_url %}
+        <p><a href="{{ catalog_url }}" target="_blank">Текущий файл</a></p>
+        {% endif %}
+        <input type="file" class="form-control" id="catalog-file" name="catalog_file" />
+      </div>
       <button type="submit" class="btn btn-primary">Сохранить</button>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- update the "Мои Чеки" section messaging for inactive/active promos and tailor responses for first vs. subsequent receipt uploads
- deliver the FINSKY ICE cocktail catalog on the first receipt submission when uploaded in settings
- extend admin settings/API to upload and expose the catalog file alongside existing policy and rules assets

## Testing
- python -m compileall heandlers site_bot

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c5ddc80f883279b4c25d41f6d11ce)